### PR TITLE
Update spelling of "context"

### DIFF
--- a/cheatsheets/jekyll/plugins/custom.md
+++ b/cheatsheets/jekyll/plugins/custom.md
@@ -82,7 +82,7 @@ If you need access to `site`, such as for making a static file.
 module Jekyll
   module Foo
     def foo(source, options)
-      site = @contextension.registers[:site]
+      site = @context.registers[:site]
       
       # ...
   


### PR DESCRIPTION
This changes the current text:

      site = @contextension.registers[:site]

To match the Jekyll docs:

      site = @context.registers[:site]